### PR TITLE
Adds support to run migrations in docker build/up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,14 @@ RUN apt-get update && apt-get install -y \
 ENV APP_HOME /srv/app
 
 ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \
-    BUNDLE_JOBS=8 \
-    BUNDLE_PATH=/bundle_cache
+    BUNDLE_JOBS=8 
 
-WORKDIR $APP_HOME
+ENV PATH=$APP_HOME/test/dummy/bin:$PATH
+
+RUN gem install bundler
+
+COPY . $APP_HOME/
+RUN bundle check || bundle install
+
+WORKDIR $APP_HOME/test/dummy
+RUN rails db:create db:migrate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,16 @@
-app:
-  container_name: planter_app
-  build: .
-  dockerfile: Dockerfile
-  volumes:
-    - .:/srv/app
-  volumes_from:
-    - bundle_cache
-bundle_cache:
-  container_name: planter_bundle_cache
-  image: busybox
-  volumes:
-    - /bundle_cache
+version: '3'
+
+volumes:
+  bundle_cache:
+
+services:
+  app:
+    container_name: planter_app
+    build:
+      context: .
+    command: >  
+      bash -c "bin/rails db:create &&
+               bin/rails db:migrate"
+    volumes:
+      - .:/srv/app
+      - bundle_cache:/usr/local/lib


### PR DESCRIPTION
With this PR, db creation and migrations will be performed on both `docker build` and `docker-compose up`. I have also added support for running rails commands through docker-compose cli. To run test, you can now execute `docker-compose run app rails test`.