### PR TITLE
changes dependency on rails to 7.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     planter (0.2.0)
-      rails (~> 7.0.2.3)
+      rails (~> 7.0)
 
 GEM
   remote: https://rubygems.org/

--- a/planter.gemspec
+++ b/planter.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
     'https://evanthegrayt.github.io/planter/'
 
   spec.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
-  spec.add_dependency "rails", "~> 7.0.2.3"
+  spec.add_dependency "rails", "~> 7.0"
 end


### PR DESCRIPTION
The dependency on rails was too specific, with rails now at `7.0.3` planter was unable to be installed on that version of rails. I changed the dependency to be rails 7.0 which will allow this to work for all rails versions from `7.0` up until they release `7.1`

I am currently using my github fork in a rails project with rails 7.0.3 and have had no issues. (granted I have not tested csv seeding)